### PR TITLE
Add contributor docs and ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,6 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# Claude Code per-machine local settings
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# Flow.ConfluenceSearch
+
+Flow Launcher plugin (C# / .NET 9, WPF) that searches Confluence Cloud via the
+REST API and opens results in the browser. Triggered with the `conf` action
+keyword.
+
+For deeper docs see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md),
+[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md), and
+[`docs/QUERY-SYNTAX.md`](docs/QUERY-SYNTAX.md).
+
+## Repository layout
+
+- `Flow.ConfluenceSearch/` — plugin assembly
+  - `Main.cs` — entry point, implements `IAsyncPlugin`, `ISettingProvider`
+  - `ServiceProvider.cs` — DI registration (`Microsoft.Extensions.DependencyInjection`)
+  - `ConfluenceClient/`
+    - `ConfluenceSearchClient.cs` — HTTP call to `/wiki/rest/api/search`
+    - `ConfluenceQueryBuilder.cs` — parses the user query into CQL
+      (for the API call) and into URL parameters (for the "open in browser"
+      fallback). Uses the fluent pipeline in `QueryBuilderExtensions.cs`.
+    - `ConfluenceSearchPage.cs` — DTOs for the API response
+  - `Search/`
+    - `Searcher.cs` — orchestrates query → CQL → API call → `Result` list,
+      with a 300 ms debounce and per-call timeout
+    - `ResultCreator.cs` — builds `Flow.Launcher.Plugin.Result` items, opens
+      URLs via `Process.Start(... UseShellExecute=true)`
+    - `ResultContext.cs` — data carried on each result
+  - `Settings/` — WPF settings panel (`SettingsView.xaml(.cs)`,
+    `SettingsViewModel.cs`, `PluginSettings.cs`, `Configurator.cs`)
+  - `plugin.json` — Flow Launcher manifest (action keyword `conf`, ID,
+    version, icon)
+  - `Build-Plugin.ps1` — packages the plugin into a ZIP for manual install
+  - `Start.ps1` — local dev helper: stops Flow Launcher, builds, copies the
+    output into `%APPDATA%\FlowLauncher\Plugins\Confluence Search-1.0.1`,
+    restarts Flow Launcher
+- `Flow.ConfluenceSearch.Test/` — xUnit v3 + Shouldly + NSubstitute tests
+  (the only test project referenced by the solution)
+- `Flow.ConfluenceSearch.Tests/` — empty placeholder, **not** part of the
+  solution; ignore it
+- `.github/workflows/`
+  - `build-action.yml` — PR build (`dotnet publish` win-x64)
+  - `publish-action.yml` — release on push to `master`, tags `v<plugin.json
+    Version>`, attaches the published ZIP
+
+## Build & test
+
+```powershell
+dotnet restore
+dotnet build Flow.ConfluenceSearch.sln -c Release
+dotnet test  Flow.ConfluenceSearch.sln
+```
+
+For interactive plugin development, run `Flow.ConfluenceSearch\Start.ps1`
+from the project directory — it stops Flow Launcher, rebuilds, copies the
+DLLs into the plugin folder and relaunches.
+
+For producing an installable ZIP, run `Flow.ConfluenceSearch\Build-Plugin.ps1`.
+
+The publish workflow tags releases from the `Version` field in
+`Flow.ConfluenceSearch/plugin.json` — bumping that field on `master` is what
+triggers a new GitHub release.
+
+## Query language (handled by `ConfluenceQueryBuilder`)
+
+The user types a query after `conf`. Tokens are space-separated and
+order-independent:
+
+| Token         | Effect                                                               |
+|---------------|----------------------------------------------------------------------|
+| `#all`        | Ignore default-spaces filter                                         |
+| `#KEY`        | Restrict to space `KEY` (repeatable)                                 |
+| `@me`         | `contributor = currentUser()`                                        |
+| `@name`       | `contributor.fullname ~ name` (repeatable, OR-combined with `@me`)   |
+| `+label`      | `label IN (...)` (repeatable)                                        |
+| `/`           | type=folder                                                          |
+| `"`           | type=blogpost                                                        |
+| `.`           | type=page                                                            |
+| `*`           | All types (skip the default `type IN(page,blogpost)` filter)         |
+| anything else | Free-text → `(title ~ "tok*" OR text ~ "tok*")`                      |
+
+If no `#KEY` is given, `PluginSettings.DefaultSpaces` is applied. CQL is
+always suffixed with `order by lastmodified DESC`.
+
+`ConfluenceQueryBuilderTest.cs` is the canonical reference for expected CQL
+strings — when changing the builder, update or add an `[InlineData]` row
+there.
+
+## Architecture notes
+
+- DI is wired in `ServiceProvider.ConfigureServices`. `PluginInitContext` and
+  `PluginSettings` are singletons; everything else is scoped.
+- `HttpClient` is created per call via a `Func<HttpClient>` factory because
+  `BaseUrl`, `ApiToken` and `Timeout` come from settings that the user can
+  edit at runtime — capturing a single `HttpClient` would freeze stale
+  values.
+- Auth is HTTP Basic with the API token base64-encoded in
+  `Authorization: Basic`. For Atlassian Cloud the username portion is the
+  account email; the plugin currently sends only the token, which works
+  because Atlassian also accepts `Bearer`-style tokens in the basic header
+  for some endpoints — verify against the user's tenant if 401s appear.
+- `Searcher.QueryAsync` does a 300 ms `Task.Delay` debounce, then runs the
+  request under a linked CTS that combines Flow Launcher's cancellation
+  token with a per-call timeout (clamped to 3–30 s).
+- `internalsVisibleTo` is set for the test assembly and for Castle/DynamicProxy
+  so NSubstitute can mock `internal` interfaces.
+
+## Conventions
+
+- Target framework: `net9.0-windows`, nullable enabled, WPF (`UseWpf`).
+- Public API surface is intentionally small — most types are `internal` and
+  exposed to the test project via `InternalsVisibleTo`.
+- Tests use **xUnit v3** (`xunit.v3` package, `TestContext.Current.CancellationToken`),
+  Shouldly for assertions, NSubstitute for mocks. Don't introduce other
+  frameworks.
+- Code style follows the default .NET conventions; primary constructors are
+  used throughout for DI (e.g. `Searcher(...)`, `ResultCreator(...)`).
+- The plugin ID in `plugin.json` (`EE691863-...`) and the one hardcoded in
+  `Build-Plugin.ps1` (`BD32A62C-...`) currently differ. The manifest is
+  authoritative — the script's value is unused (it isn't written into the
+  output) but should be aligned the next time the script is touched.
+
+## Known wrinkles
+
+- The CI publish workflow listens on `master`, but the default branch is
+  `main`. Pushes to `main` therefore won't currently trigger a release —
+  fix the trigger before depending on it.
+- `Flow.ConfluenceSearch.Tests/` (with an `s`) sits next to the real
+  `Flow.ConfluenceSearch.Test/` and contains an empty file. It is not in
+  the solution; safe to delete if cleaning up.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ dotnet test
 4. Add tests if applicable.
 5. Submit a pull request.
 
+For contributors there is additional documentation under [`docs/`](docs/):
+
+- [Architecture](docs/ARCHITECTURE.md) — solution layout, request lifecycle, DI setup.
+- [Development](docs/DEVELOPMENT.md) — build/test commands, hot-swap dev loop, CI/release flow.
+- [Query syntax](docs/QUERY-SYNTAX.md) — full reference of the `conf` query language.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,103 @@
+# Architecture
+
+Flow.ConfluenceSearch is a [Flow Launcher](https://flowlauncher.com/) plugin
+written in C# / .NET 9 (WPF). It searches Confluence Cloud through the REST
+API and is invoked with the `conf` action keyword.
+
+## Solution layout
+
+```
+Flow.ConfluenceSearch.sln
+├── Flow.ConfluenceSearch/           Plugin assembly
+│   ├── Main.cs                      Entry point (IAsyncPlugin, ISettingProvider)
+│   ├── ServiceProvider.cs           DI container wiring
+│   ├── plugin.json                  Flow Launcher manifest
+│   ├── ConfluenceClient/            HTTP + CQL builder
+│   │   ├── ConfluenceSearchClient.cs
+│   │   ├── ConfluenceQueryBuilder.cs
+│   │   ├── QueryBuilderExtensions.cs
+│   │   └── ConfluenceSearchPage.cs  Response DTOs
+│   ├── Search/
+│   │   ├── Searcher.cs              Orchestrates query → CQL → results
+│   │   ├── ResultCreator.cs         Builds Flow Launcher Result items
+│   │   └── ResultContext.cs
+│   ├── Settings/                    WPF settings panel
+│   │   ├── SettingsView.xaml(.cs)
+│   │   ├── SettingsViewModel.cs
+│   │   ├── PluginSettings.cs
+│   │   └── Configurator.cs
+│   ├── Build-Plugin.ps1             Packages plugin into a ZIP
+│   └── Start.ps1                    Local hot-swap dev script
+└── Flow.ConfluenceSearch.Test/      xUnit v3 + Shouldly + NSubstitute
+```
+
+> The folder `Flow.ConfluenceSearch.Tests/` (with an `s`) sits next to the
+> real test project, contains an empty file, and is **not** referenced by the
+> solution. It can be removed.
+
+## Request lifecycle
+
+1. Flow Launcher invokes `Main.QueryAsync(query, ct)`.
+2. `Searcher.QueryAsync`
+   - waits 300 ms (debounce — typing further cancels via `TaskCanceledException`)
+   - links the caller's cancellation token with a per-call timeout
+     (`PluginSettings.Timeout`, clamped to 3–30 s)
+   - if the query is empty, returns the static "hint" results
+3. `ConfluenceQueryBuilder.BuildTextCql` parses the user input into CQL.
+   `BuildQueryForOpenInBrowser` produces a fallback URL for the
+   "open search in browser" action.
+4. `ConfluenceSearchClient.SearchCqlAsync` calls
+   `GET /wiki/rest/api/search?cql=…&limit=…&expand=content.history.lastUpdated`
+   and deserializes `ContentSearchResponse`.
+5. `ResultCreator.CreateResult` wraps each hit as a Flow Launcher `Result`.
+   Activating a result opens its URL via `Process.Start(... UseShellExecute=true)`.
+
+## Dependency injection
+
+`ServiceProvider.ConfigureServices` (called from `Main.InitAsync`) registers:
+
+| Lifetime  | Registration |
+|-----------|--------------|
+| Singleton | `PluginInitContext`, `PluginSettings` |
+| Singleton | `Func<HttpClient>` factory (see below) |
+| Scoped    | `IConfluenceSearchClient`, `IConfluenceQueryBuilder`, `IResultCreator`, `IConfigurator`, `ISearcher`, `SettingsViewModel` |
+
+### Why a `Func<HttpClient>`?
+
+`BaseUrl`, `ApiToken`, and `Timeout` come from settings the user can edit at
+runtime. A captured singleton `HttpClient` would freeze stale values, so the
+factory creates a fresh client per call, configured with the current
+settings. Each created client is `using`-disposed after the request.
+
+Authentication uses HTTP Basic with the API token base64-encoded in the
+`Authorization` header.
+
+## Visibility & testability
+
+Most types in the plugin assembly are `internal`. The csproj exposes them to
+the test assembly and to NSubstitute via `InternalsVisibleTo`:
+
+- `Flow.ConfluenceSearch.Test`
+- `Castle.Core`
+- `DynamicProxyGenAssembly2`
+
+This lets tests substitute `internal` interfaces (e.g. `IConfluenceSearchClient`)
+without making them public.
+
+## Settings
+
+`PluginSettings` is loaded via Flow Launcher's `LoadSettingJsonStorage<T>()`
+and contains:
+
+| Field            | Default                   |
+|------------------|---------------------------|
+| `BaseUrl`        | `"https://www.example.com"` |
+| `ApiToken`       | `""`                      |
+| `Timeout`        | `00:00:10`                |
+| `MaxResults`     | `10`                      |
+| `DefaultSpaces`  | `[]`                      |
+
+The settings UI (`SettingsView.xaml`) binds directly to `Settings.*`. The
+API token uses a `PasswordBox` whose `PasswordChanged` handler writes to
+`Settings.ApiToken` in the code-behind (passwords cannot be two-way-bound
+in WPF without unsafe workarounds).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,105 @@
+# Development
+
+## Prerequisites
+
+- Windows 10/11
+- .NET SDK 9.0
+- Flow Launcher (only required for end-to-end testing)
+
+## Build & test
+
+```powershell
+dotnet restore
+dotnet build Flow.ConfluenceSearch.sln -c Release
+dotnet test  Flow.ConfluenceSearch.sln
+```
+
+The solution targets `net9.0-windows`, has nullable reference types enabled,
+and uses WPF (`UseWpf=true`).
+
+## Test stack
+
+Tests live in `Flow.ConfluenceSearch.Test/`. The stack:
+
+- **xUnit v3** (`xunit.v3`) — note that v3 uses
+  `TestContext.Current.CancellationToken` inside `[Theory]`/`[Fact]` methods
+  rather than injecting a `CancellationToken` parameter.
+- **Shouldly** for assertions (`x.ShouldBe(...)`, `Should.ThrowAsync<...>`).
+- **NSubstitute** for mocks. Internal interfaces are mockable thanks to the
+  `InternalsVisibleTo` attributes on the production project.
+
+When changing `ConfluenceQueryBuilder`, add or update `[InlineData]` rows on
+`BuildTextCqlTest` / `BuildQueryForOpenInBrowserTest` in
+`ConfluenceQueryBuilderTest.cs`. Those tables are the spec for the query
+language.
+
+## Local hot-swap loop
+
+For interactive testing inside Flow Launcher, run from the project directory:
+
+```powershell
+.\Flow.ConfluenceSearch\Start.ps1
+```
+
+The script:
+
+1. Stops the `Flow.Launcher` process.
+2. Runs `dotnet build` (Debug by default; pass `-BuildConfig Release` to
+   switch).
+3. Copies `bin\Debug\net9.0-windows\*` into
+   `%APPDATA%\FlowLauncher\Plugins\Confluence Search-1.0.1`.
+4. Restarts `%LOCALAPPDATA%\FlowLauncher\Flow.Launcher.exe`.
+
+> The default plugin folder name embeds the version (`1.0.1`). When the
+> manifest version changes, either pass `-PluginFolderName "Confluence Search-x.y.z"`
+> or update the script default — otherwise new builds keep landing in the
+> old folder.
+
+## Producing a release ZIP
+
+```powershell
+.\Flow.ConfluenceSearch\Build-Plugin.ps1
+```
+
+This builds in Release, copies the required DLLs and assets into
+`dist\temp\Flow.ConfluenceSearch\`, zips them as
+`Flow.ConfluenceSearch-v<version>.zip`, and prints the resulting path. The
+ZIP can be installed via Flow Launcher → Settings → Plugins → Install Plugin.
+
+## CI / release
+
+- `.github/workflows/build-action.yml` — builds every PR via
+  `dotnet publish ... -r win-x64 --no-self-contained` and uploads the result
+  as an artifact.
+- `.github/workflows/publish-action.yml` — on push, reads `Version` from
+  `Flow.ConfluenceSearch/plugin.json`, publishes the build, and creates a
+  GitHub release tagged `v<Version>` if the version differs from the
+  latest existing release.
+
+> **Heads-up:** the publish workflow's `on: push:` is currently configured
+> for the `master` branch, while the repo's default branch is `main`.
+> Pushes to `main` therefore do not trigger a release; bumping
+> `plugin.json` Version on `main` has no effect until the trigger is
+> updated to include `main`.
+
+## Versioning
+
+The single source of truth for the plugin version is the `Version` field in
+`Flow.ConfluenceSearch/plugin.json`. Bump it before merging a release-worthy
+change. The publish workflow tags `v<Version>` and uploads the ZIP under
+that name.
+
+> The plugin GUID in `plugin.json` (`EE691863-…`) and the one hard-coded in
+> `Build-Plugin.ps1` (`BD32A62C-…`) currently differ. Flow Launcher reads
+> the manifest, so the discrepancy is harmless today, but the script's
+> value should be aligned the next time it's touched.
+
+## Code conventions
+
+- Primary constructors are used throughout for DI (e.g.
+  `Searcher(IConfluenceSearchClient ..., …) : ISearcher`).
+- Most types are `internal` and exposed to tests via `InternalsVisibleTo`;
+  prefer `internal` for new types unless they're genuinely part of the
+  public surface.
+- DTOs use `System.Text.Json` with `[JsonPropertyName(...)]`. Don't pull in
+  Newtonsoft.Json.

--- a/docs/QUERY-SYNTAX.md
+++ b/docs/QUERY-SYNTAX.md
@@ -1,0 +1,81 @@
+# Query syntax
+
+The `conf` action keyword takes a free-form query made of space-separated
+tokens. `ConfluenceQueryBuilder` parses the tokens (in any order) and
+produces:
+
+1. A **CQL query** for the Confluence REST search endpoint.
+2. A **URL parameter string** used as a fallback for "open this search in
+   the browser" when the API call returns nothing or the user wants more
+   results.
+
+## Tokens
+
+| Token         | Effect on CQL                                                     |
+|---------------|-------------------------------------------------------------------|
+| `#all`        | Disables the default-spaces filter (no `space IN (...)` clause).  |
+| `#KEY`        | Restricts to space `KEY`. Repeatable (`#A #B` → `space IN (A,B)`). |
+| `@me`         | `contributor = currentUser()`.                                    |
+| `@name`       | `contributor.fullname ~ name`. Repeatable. Combined with `@me` via `OR`. |
+| `+label`      | `label IN (label)`. Repeatable.                                   |
+| `/`           | `type IN (folder)`.                                               |
+| `"`           | `type IN (blogpost)`.                                             |
+| `.`           | `type IN (page)`.                                                 |
+| `*`           | Skip the type filter entirely (default is `type IN(page,blogpost)`). |
+| any other     | Free-text term → `(title ~ "tok*" OR text ~ "tok*")`.             |
+
+The CQL output is always suffixed with `order by lastmodified DESC`.
+
+If no `#KEY` and no `#all` are given, the spaces from `Default Spaces` in
+the plugin settings are applied.
+
+## Examples
+
+```
+conf project plan
+→ space IN (DEFAULTS) AND type IN(page,blogpost)
+   AND (title~"project* plan*" OR text~"project* plan*")
+   order by lastmodified DESC
+
+conf @me #docs
+→ space IN (docs) AND type IN(page,blogpost)
+   AND (contributor = currentUser())
+   order by lastmodified DESC
+
+conf #all meeting notes
+→ type IN(page,blogpost)
+   AND (title~"meeting* notes*" OR text~"meeting* notes*")
+   order by lastmodified DESC
+
+conf @john +retro /
+→ space IN (DEFAULTS) AND type IN(folder) AND label IN (retro)
+   AND (contributor.fullname ~ john)
+   order by lastmodified DESC
+```
+
+The full list of expected CQL outputs is encoded as `[InlineData]` rows on
+`Flow.ConfluenceSearch.Test/ConfluenceQueryBuilderTest.cs`. Treat that file
+as the canonical specification.
+
+## Internals
+
+The builder is implemented as a small fluent pipeline in
+`QueryBuilderExtensions.cs`. Each `When(regex)` step matches whole tokens,
+optionally captures groups, and feeds them into `Then…` actions:
+
+- `Then(part)` — append a literal CQL fragment.
+- `ThenRemember(value)` — push a literal value into a memory buffer.
+- `ThenRemember()` — push the captured group(s) into the buffer.
+- `ThenRemember(convert)` — async-transform captures before pushing.
+- `ThenDoNothing()` — match-and-consume without side effects (used for
+  `*` and `#all`).
+- `Aggregate(fn)` — fold the buffer into one CQL part and clear it.
+- `Else(part)` — fallback CQL part if no match in the preceding `When` chain.
+- `BuildCql(separator)` — join all collected parts with `AND` (CQL) or
+  `&` (URL parameters).
+
+Free-text escaping for the CQL `~` operator happens in
+`ConfluenceQueryBuilder.EscapeForCqlToken`: each token is `Trim`med, the
+trailing `*` is removed, the special characters
+`\ * + - ! ( ) : ^ [ ] { } ~ ? | & / " '` are backslash-escaped, and a
+single trailing `*` is appended for prefix matching.


### PR DESCRIPTION
## Summary

Mirrors the docs layout Flow.JiraSearch uses (haugjan/Flow.JiraSearch#14):

- `CLAUDE.md` as a self-contained project overview (repo layout, build/test, query-language table, architecture notes, conventions, wrinkles).
- `docs/ARCHITECTURE.md` — solution layout, request lifecycle, DI wiring.
- `docs/DEVELOPMENT.md` — build/test, hot-swap loop, CI/release flow.
- `docs/QUERY-SYNTAX.md` — full reference for the `conf` query DSL.
- `README.md` gets a Contributing → docs/ link.

Also adds `.claude/settings.local.json` (per-machine Claude Code permissions) to `.gitignore`.

## Test plan

- [ ] `docs/*.md` and `CLAUDE.md` render correctly on GitHub.
- [ ] `README.md` link to `docs/` works.
- [ ] No source code changed; nothing to build or test.