### PR TITLE
Surface Confluence auth errors and clarify Cloud token format (1.1.0)

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -2,7 +2,7 @@ name: Publish Release
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
       - .github/workflows/*
       - .gitignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ For deeper docs see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md),
   solution; ignore it
 - `.github/workflows/`
   - `build-action.yml` — PR build (`dotnet publish` win-x64)
-  - `publish-action.yml` — release on push to `master`, tags `v<plugin.json
+  - `publish-action.yml` — release on push to `main`, tags `v<plugin.json
     Version>`, attaches the published ZIP
 
 ## Build & test
@@ -57,7 +57,7 @@ DLLs into the plugin folder and relaunches.
 For producing an installable ZIP, run `Flow.ConfluenceSearch\Build-Plugin.ps1`.
 
 The publish workflow tags releases from the `Version` field in
-`Flow.ConfluenceSearch/plugin.json` — bumping that field on `master` is what
+`Flow.ConfluenceSearch/plugin.json` — bumping that field on `main` is what
 triggers a new GitHub release.
 
 ## Query language (handled by `ConfluenceQueryBuilder`)
@@ -121,9 +121,6 @@ there.
 
 ## Known wrinkles
 
-- The CI publish workflow listens on `master`, but the default branch is
-  `main`. Pushes to `main` therefore won't currently trigger a release —
-  fix the trigger before depending on it.
 - `Flow.ConfluenceSearch.Tests/` (with an `s`) sits next to the real
   `Flow.ConfluenceSearch.Test/` and contains an empty file. It is not in
   the solution; safe to delete if cleaning up.

--- a/Flow.ConfluenceSearch.Test/ConfluenceSearchClientTests.cs
+++ b/Flow.ConfluenceSearch.Test/ConfluenceSearchClientTests.cs
@@ -89,17 +89,29 @@ public class ConfluenceSearchClientTests : IDisposable
     }
 
     [Fact]
-    public async Task SearchCqlAsync_WhenApiReturnsError_ThrowsApplicationException()
+    public async Task SearchCqlAsync_WithHttpError_ThrowsHttpRequestExceptionCarryingStatusCode()
     {
         // Arrange
-        var errorContent = "server error details";
-        _httpMessageHandler.SetResponse(HttpStatusCode.InternalServerError, errorContent);
+        _httpMessageHandler.SetResponse(HttpStatusCode.InternalServerError, "server error details");
 
         // Act & Assert
-        var ex = await Should.ThrowAsync<ApplicationException>(async () =>
-            await _searchClient.SearchCqlAsync("invalid cql", 10, CancellationToken.None)
+        var ex = await Should.ThrowAsync<HttpRequestException>(() =>
+            _searchClient.SearchCqlAsync("invalid cql", 10, CancellationToken.None)
         );
-        ex.Message.ShouldContain(errorContent);
+        ex.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+    }
+
+    [Fact]
+    public async Task SearchCqlAsync_WithUnauthorized_ThrowsHttpRequestExceptionWith401()
+    {
+        // Arrange
+        _httpMessageHandler.SetResponse(HttpStatusCode.Unauthorized, "Unauthorized");
+
+        // Act & Assert
+        var ex = await Should.ThrowAsync<HttpRequestException>(() =>
+            _searchClient.SearchCqlAsync("any cql", 10, CancellationToken.None)
+        );
+        ex.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
 
     [Fact]

--- a/Flow.ConfluenceSearch/ConfluenceClient/ConfluenceSearchClient.cs
+++ b/Flow.ConfluenceSearch/ConfluenceClient/ConfluenceSearchClient.cs
@@ -6,12 +6,12 @@ namespace Flow.ConfluenceSearch.ConfluenceClient;
 
 internal interface IConfluenceSearchClient
 {
-    Task<ContentSearchResponse> SearchCqlAsync(string cql, int maxResults, CancellationToken ct);
+    Task<ContentSearchResponse?> SearchCqlAsync(string cql, int maxResults, CancellationToken ct);
 }
 
 internal sealed class ConfluenceSearchClient(Func<HttpClient> httpFactory) : IConfluenceSearchClient
 {
-    public async Task<ContentSearchResponse> SearchCqlAsync(
+    public async Task<ContentSearchResponse?> SearchCqlAsync(
         string cql,
         int maxResults,
         CancellationToken ct
@@ -24,13 +24,10 @@ internal sealed class ConfluenceSearchClient(Func<HttpClient> httpFactory) : ICo
         using var req = new HttpRequestMessage(HttpMethod.Get, url);
         using var resp = await http.SendAsync(req, ct).ConfigureAwait(false);
 
-        if (!resp.IsSuccessStatusCode)
-            throw new ApplicationException(
-                $"Error in API Call: {await resp.Content.ReadAsStringAsync(ct)}"
-            );
+        resp.EnsureSuccessStatusCode();
 
         return await resp
             .Content.ReadFromJsonAsync<ContentSearchResponse>(cancellationToken: ct)
-            .ConfigureAwait(false) ?? throw new ApplicationException("Invalid response from Confluence API");
+            .ConfigureAwait(false);
     }
 }

--- a/Flow.ConfluenceSearch/Search/ResultCreator.cs
+++ b/Flow.ConfluenceSearch/Search/ResultCreator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Net;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Flow.ConfluenceSearch.Settings;
@@ -26,6 +27,10 @@ internal interface IResultCreator
         string originalQuery,
         string searchTextInBrowser
     );
+
+    Result CreateAuthError();
+
+    Result CreateApiError(HttpStatusCode? status, string message);
 }
 
 internal class ResultCreator(PluginSettings settings) : IResultCreator
@@ -77,6 +82,28 @@ internal class ResultCreator(PluginSettings settings) : IResultCreator
                 return Open(url);
             },
             CopyText = $"{settings.BaseUrl}/wiki/search?{searchTextInBrowser}",
+        };
+
+    public Result CreateAuthError() =>
+        new()
+        {
+            Title = "Confluence authentication failed (HTTP 401)",
+            SubTitle =
+                "Did you paste the API Token as 'your-email@example.com:apitoken'? "
+                + "Click for setup help.",
+            IcoPath = "Images/gray.png",
+            Action = _ => Open("https://github.com/haugjan/Flow.ConfluenceSearch#configuration"),
+        };
+
+    public Result CreateApiError(HttpStatusCode? status, string message) =>
+        new()
+        {
+            Title = status.HasValue
+                ? $"Confluence request failed (HTTP {(int)status.Value} {status.Value})"
+                : "Confluence request failed",
+            SubTitle = message,
+            IcoPath = "Images/gray.png",
+            Action = _ => false,
         };
 
     private bool Open(string url)

--- a/Flow.ConfluenceSearch/Search/Searcher.cs
+++ b/Flow.ConfluenceSearch/Search/Searcher.cs
@@ -1,4 +1,5 @@
-﻿using Flow.ConfluenceSearch.ConfluenceClient;
+﻿using System.Net.Http;
+using Flow.ConfluenceSearch.ConfluenceClient;
 using Flow.ConfluenceSearch.Settings;
 using Flow.Launcher.Plugin;
 
@@ -90,9 +91,27 @@ internal sealed class Searcher(
             timeoutCts.Token
         );
 
-        var data = await confluenceSearch
-            .SearchCqlAsync(cql, settings.MaxResults, linkedCts.Token)
-            .ConfigureAwait(false);
+        ContentSearchResponse? data;
+        try
+        {
+            data = await confluenceSearch
+                .SearchCqlAsync(cql, settings.MaxResults, linkedCts.Token)
+                .ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+            when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+        {
+            context.API.LogException(nameof(Searcher), "Confluence authentication failed", ex);
+            return [resultCreator.CreateAuthError()];
+        }
+        catch (HttpRequestException ex)
+        {
+            context.API.LogException(nameof(Searcher), "Confluence request failed", ex);
+            return [resultCreator.CreateApiError(ex.StatusCode, ex.Message)];
+        }
+
+        if (data is null)
+            return [resultCreator.CreateApiError(null, "Empty response from Confluence.")];
 
         var results = new List<Result>();
 

--- a/Flow.ConfluenceSearch/Settings/SettingsView.xaml
+++ b/Flow.ConfluenceSearch/Settings/SettingsView.xaml
@@ -44,7 +44,7 @@
       Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
       VerticalAlignment="Center"
       FontSize="14"
-      Text="API Token"
+      Text="API Token (Cloud: email:token)"
     />
     <PasswordBox
       x:Name="MaxDecimalPlaces"

--- a/Flow.ConfluenceSearch/plugin.json
+++ b/Flow.ConfluenceSearch/plugin.json
@@ -6,7 +6,7 @@
   "Name": "Confluence Search",
   "Description": "Search for and open Confluence pages directly from Flow Launcher.",
   "Author": "Jan Haug",
-  "Version": "1.0.1",
+  "Version": "1.1.0",
   "Language": "csharp",
   "Website": "https://github.com/haugjan/Flow.ConfluenceSearch",
   "IcoPath": "Images/icon.png",

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The plugin is configured through Flow Launcher's settings interface:
    | Setting | Description | Example |
    |---------|-------------|---------|
    | **Base URL** | Your Confluence instance URL | `https://yourcompany.atlassian.net` |
-   | **API Token** | Personal API token from Confluence | `ATATT3xFfGF0...` |
+   | **API Token** | Cloud: `email:token`. Server / Data Center: token alone. See below. | `your-email@example.com:ATATT3xFfGF0...` |
    | **Timeout** | Request timeout in seconds | `10` |
    | **Max Results** | Maximum number of results to display | `10` |
    | **Default Spaces** | Space keys to search by default | `["SPACE1", "SPACE2"]` |
@@ -66,7 +66,14 @@ The plugin is configured through Flow Launcher's settings interface:
 1. Go to [Atlassian Account Settings](https://id.atlassian.com/manage-profile/security/api-tokens).
 2. Click "Create API token".
 3. Give it a descriptive name (e.g., "Flow Launcher Plugin").
-4. Copy the generated token and paste it in the plugin settings.
+4. Copy the generated token.
+
+Then paste it into the plugin's **API Token** field, depending on your Confluence flavour:
+
+- **Confluence Cloud** (`*.atlassian.net`): paste `your-email@example.com:<api-token>` — the address you use to sign in to Atlassian, a colon, and the token, with no spaces. The plugin sends this as HTTP Basic auth, which is what Confluence Cloud requires.
+- **Confluence Server / Data Center**: paste the personal access token alone.
+
+If authentication fails the plugin shows `Confluence authentication failed (HTTP 401)` in the result list — the most common cause is missing the `email:` prefix on Confluence Cloud.
 
 ## Usage
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -71,16 +71,10 @@ ZIP can be installed via Flow Launcher → Settings → Plugins → Install Plug
 - `.github/workflows/build-action.yml` — builds every PR via
   `dotnet publish ... -r win-x64 --no-self-contained` and uploads the result
   as an artifact.
-- `.github/workflows/publish-action.yml` — on push, reads `Version` from
-  `Flow.ConfluenceSearch/plugin.json`, publishes the build, and creates a
-  GitHub release tagged `v<Version>` if the version differs from the
-  latest existing release.
-
-> **Heads-up:** the publish workflow's `on: push:` is currently configured
-> for the `master` branch, while the repo's default branch is `main`.
-> Pushes to `main` therefore do not trigger a release; bumping
-> `plugin.json` Version on `main` has no effect until the trigger is
-> updated to include `main`.
+- `.github/workflows/publish-action.yml` — on push to `main`, reads
+  `Version` from `Flow.ConfluenceSearch/plugin.json`, publishes the build,
+  and creates a GitHub release tagged `v<Version>` if the version differs
+  from the latest existing release.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

Fixes #7. The plugin previously accepted a bare API token in the settings field and threw the API response body as an `ApplicationException` that bubbled up to Flow Launcher and produced an empty result list, so a Confluence Cloud user who pasted only the token (which is what the README example showed) saw "No results" with no indication that auth was failing. Mirrors the Jira-side fix at haugjan/Flow.JiraSearch#17.

- `ConfluenceSearchClient` now calls `EnsureSuccessStatusCode`, so failures surface as `HttpRequestException` with the actual status code instead of being mapped to an opaque `ApplicationException`, and the response is allowed to be null on empty payload.
- `Searcher` catches that and shows an explicit `Confluence authentication failed (HTTP 401)` result on 401 — the subtitle asks the user whether they pasted the token as `email@example.com:apitoken` and the row clicks through to the README configuration section. Other status codes produce a generic `Confluence request failed (HTTP <code>)` hint instead of an empty list.
- Settings panel relabels the field to `API Token (Cloud: email:token)`.
- README explains the `email:token` format for Cloud and that Server / Data Center installs still take the token alone.

Also as part of this release:

- **Fix publish workflow trigger** from `master` to `main` so pushes to the default branch actually cut releases. Bumping `plugin.json:Version` on `main` now produces a `v<Version>` tag and attaches the published ZIP automatically.
- Drop the resolved master-vs-main wrinkle from `CLAUDE.md` and `docs/DEVELOPMENT.md`.
- Bumps version to `1.1.0`.

## Test plan

- [x] `dotnet build Flow.ConfluenceSearch.sln -c Debug` — clean, no warnings.
- [x] `dotnet run --project Flow.ConfluenceSearch.Test --no-build` — 43/43 pass. The existing `WhenApiReturnsError_ThrowsApplicationException` was rewritten as `WithHttpError_ThrowsHttpRequestExceptionCarryingStatusCode`, and a 401-specific case was added.
- [ ] On merge, the `Publish Release` workflow runs against `main`, builds `ConfluenceSearch-1.1.0.zip`, and creates a `v1.1.0` GitHub release with the ZIP attached.
- [ ] After the manifest PR (Flow-Launcher/Flow.Launcher.PluginsManifest#652) is merged, the next scheduled `Auto Update` run picks up `v1.1.0` for the Confluence Search entry.
- [ ] Manual smoke test on Confluence Cloud after release: plugin shows the auth-error hint when the token is missing the `email:` prefix, and works once the format is corrected.