### PR TITLE
Skip publish steps when version unchanged

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -51,12 +51,14 @@ jobs:
           dotnet-version: 9.0.x
 
       - name: Build (publish)
+        if: steps.gate.outputs.required == 'True'
         run: |
           $out = "out/ConfluenceSearch-${{ steps.version.outputs.prop }}"
           dotnet publish "Flow.ConfluenceSearch/Flow.ConfluenceSearch.csproj" -c Release -r win-x64 --no-self-contained -o "$out"
           powershell -NoProfile -Command "Compress-Archive -Path $out\* -DestinationPath 'ConfluenceSearch-${{ steps.version.outputs.prop }}.zip' -Force"
 
       - name: Publish GitHub Release
+        if: steps.gate.outputs.required == 'True'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.prop }}


### PR DESCRIPTION
## Summary

The publish workflow had a `gate` step (`steps.gate.outputs.required`) that already computes whether `plugin.json:Version` differs from the latest release tag, but the **Build (publish)** and **Publish GitHub Release** steps ran unconditionally. That meant every push to `main` re-built the plugin and tried to overwrite the existing release asset, even on tooling-only PRs that did not bump the version.

Once the Flow Launcher PluginsManifest auto-updater visits a release the asset becomes immutable, and the next push lands on `Cannot delete asset from an immutable release` (which is what just happened on the Jira side: haugjan/Flow.JiraSearch run [25213527964](https://github.com/haugjan/Flow.JiraSearch/actions/runs/25213527964)). Confluence's `v1.1.0` was not yet immutable at the time, so the same workflow shape silently re-uploaded the asset there — wasteful but unobservable.

This PR gates both steps on `steps.gate.outputs.required == 'True'` so unchanged versions cleanly skip the publish path.

`.github/workflows/publish-action.yml` itself is in the workflow's `paths-ignore`, so this PR does not trigger the workflow — the fix only takes effect on the next push that touches non-ignored paths.

Mirror PR on the Jira side: haugjan/Flow.JiraSearch#TBD.

## Test plan

- [ ] After merge, push a tooling-only change (no version bump) to `main` and confirm the workflow run shows `Build (publish)` and `Publish GitHub Release` skipped (grey, not green/red).
- [ ] On a real version bump, both steps run and the release is published.