### PR TITLE
Split Email and API Token into separate settings fields

### DIFF
--- a/Flow.ConfluenceSearch.Test/AuthHeaderBuilderTest.cs
+++ b/Flow.ConfluenceSearch.Test/AuthHeaderBuilderTest.cs
@@ -1,0 +1,51 @@
+using System.Text;
+using Flow.ConfluenceSearch.Settings;
+using Shouldly;
+
+namespace Flow.ConfluenceSearch.Test;
+
+public class AuthHeaderBuilderTest
+{
+    [Fact]
+    public void EmailAndToken_AreCombinedAsBasicCredential()
+    {
+        var header = AuthHeaderBuilder.Build("user@example.com", "secret-token");
+
+        Decode(header).ShouldBe("user@example.com:secret-token");
+    }
+
+    [Fact]
+    public void EmptyEmail_FallsBackToTokenAsIs()
+    {
+        var header = AuthHeaderBuilder.Build("", "personal-access-token");
+
+        Decode(header).ShouldBe("personal-access-token");
+    }
+
+    [Fact]
+    public void EmptyEmail_PreservesLegacyEmailColonTokenInTokenField()
+    {
+        var header = AuthHeaderBuilder.Build("", "user@example.com:secret-token");
+
+        Decode(header).ShouldBe("user@example.com:secret-token");
+    }
+
+    [Fact]
+    public void NullInputs_ProduceEmptyCredential()
+    {
+        var header = AuthHeaderBuilder.Build(null, null);
+
+        Decode(header).ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Whitespace_IsTrimmedFromBothFields()
+    {
+        var header = AuthHeaderBuilder.Build("  user@example.com  ", "  secret-token  ");
+
+        Decode(header).ShouldBe("user@example.com:secret-token");
+    }
+
+    private static string Decode(string base64) =>
+        Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+}

--- a/Flow.ConfluenceSearch/ServiceProvider.cs
+++ b/Flow.ConfluenceSearch/ServiceProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net.Http;
-using System.Text;
 using Flow.ConfluenceSearch.ConfluenceClient;
 using Flow.ConfluenceSearch.Search;
 using Flow.ConfluenceSearch.Settings;
@@ -28,7 +27,7 @@ public static class ServiceProvider
                     BaseAddress = new Uri($"{config.BaseUrl}/"),
                     Timeout = TimeSpan.FromSeconds(Math.Clamp(config.Timeout.TotalSeconds, 3, 30)),
                 };
-                var basic = Convert.ToBase64String(Encoding.UTF8.GetBytes(config.ApiToken));
+                var basic = AuthHeaderBuilder.Build(config.Email, config.ApiToken);
                 httpClient.DefaultRequestHeaders.Authorization =
                     new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", basic);
                 httpClient.DefaultRequestHeaders.Accept.ParseAdd("application/json");

--- a/Flow.ConfluenceSearch/Settings/AuthHeaderBuilder.cs
+++ b/Flow.ConfluenceSearch/Settings/AuthHeaderBuilder.cs
@@ -1,0 +1,18 @@
+using System.Text;
+
+namespace Flow.ConfluenceSearch.Settings;
+
+internal static class AuthHeaderBuilder
+{
+    public static string Build(string? email, string? apiToken)
+    {
+        var trimmedEmail = email?.Trim() ?? string.Empty;
+        var trimmedToken = apiToken?.Trim() ?? string.Empty;
+
+        var credential = trimmedEmail.Length > 0
+            ? $"{trimmedEmail}:{trimmedToken}"
+            : trimmedToken;
+
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(credential));
+    }
+}

--- a/Flow.ConfluenceSearch/Settings/PluginSettings.cs
+++ b/Flow.ConfluenceSearch/Settings/PluginSettings.cs
@@ -6,6 +6,7 @@ public record PluginSettings
     {
         BaseUrl = "https://www.example.com";
         Timeout = TimeSpan.FromSeconds(10);
+        Email = string.Empty;
         ApiToken = string.Empty;
         MaxResults = 10;
         DefaultSpaces = new List<string>();
@@ -13,6 +14,7 @@ public record PluginSettings
 
     public string BaseUrl { get; set; }
     public TimeSpan Timeout { get; set; }
+    public string Email { get; set; }
     public string ApiToken { get; set; }
     public List<string> DefaultSpaces { get; set; }
     public int MaxResults { get; set; }

--- a/Flow.ConfluenceSearch/Settings/SettingsView.xaml
+++ b/Flow.ConfluenceSearch/Settings/SettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
   x:Class="Flow.ConfluenceSearch.Settings.SettingsView"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -12,6 +12,8 @@
 >
   <Grid Margin="{StaticResource SettingPanelMargin}">
     <Grid.RowDefinitions>
+      <RowDefinition Height="auto" />
+      <RowDefinition Height="auto" />
       <RowDefinition Height="auto" />
       <RowDefinition Height="auto" />
       <RowDefinition Height="auto" />
@@ -44,11 +46,28 @@
       Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
       VerticalAlignment="Center"
       FontSize="14"
-      Text="API Token (Cloud: email:token)"
+      Text="Email (Cloud only)"
+    />
+    <TextBox
+      Grid.Row="1"
+      Grid.Column="1"
+      MaxWidth="600"
+      Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
+      HorizontalAlignment="Left"
+      VerticalAlignment="Center"
+      Text="{Binding Settings.Email, UpdateSourceTrigger=PropertyChanged}"
+    />
+    <TextBlock
+      Grid.Row="2"
+      Grid.Column="0"
+      Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
+      VerticalAlignment="Center"
+      FontSize="14"
+      Text="API Token"
     />
     <PasswordBox
       x:Name="MaxDecimalPlaces"
-      Grid.Row="1"
+      Grid.Row="2"
       Grid.Column="1"
       Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
       HorizontalAlignment="Left"
@@ -57,7 +76,21 @@
       PasswordChanged="TokenBox_PasswordChanged"
     />
     <TextBlock
-      Grid.Row="2"
+      Grid.Row="3"
+      Grid.Column="1"
+      Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
+      HorizontalAlignment="Left"
+      VerticalAlignment="Center"
+    >
+      <Hyperlink
+        NavigateUri="https://id.atlassian.com/manage-profile/security/api-tokens"
+        RequestNavigate="Hyperlink_RequestNavigate"
+      >
+        Create a Confluence Cloud API token
+      </Hyperlink>
+    </TextBlock>
+    <TextBlock
+      Grid.Row="4"
       Grid.Column="0"
       Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
       VerticalAlignment="Center"
@@ -65,7 +98,7 @@
       Text="Maximum Results"
     />
     <TextBox
-      Grid.Row="2"
+      Grid.Row="4"
       Grid.Column="1"
       MaxWidth="300"
       Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
@@ -75,7 +108,7 @@
       PreviewTextInput="NumberValidationTextBox"
     />
     <TextBlock
-      Grid.Row="3"
+      Grid.Row="5"
       Grid.Column="0"
       Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
       VerticalAlignment="Center"
@@ -83,7 +116,7 @@
       Text="Default Spaces (separate multiple with comma)"
     />
     <TextBox
-      Grid.Row="3"
+      Grid.Row="5"
       Grid.Column="1"
       MaxWidth="800"
       Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"

--- a/Flow.ConfluenceSearch/Settings/SettingsView.xaml.cs
+++ b/Flow.ConfluenceSearch/Settings/SettingsView.xaml.cs
@@ -1,6 +1,8 @@
-﻿using System.Windows;
+﻿using System.Diagnostics;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Navigation;
 
 namespace Flow.ConfluenceSearch.Settings;
 
@@ -20,5 +22,11 @@ public partial class SettingsView
     private void NumberValidationTextBox(object sender, TextCompositionEventArgs e)
     {
         e.Handled = !int.TryParse(e.Text, out _);
+    }
+
+    private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+        e.Handled = true;
     }
 }

--- a/Flow.ConfluenceSearch/plugin.json
+++ b/Flow.ConfluenceSearch/plugin.json
@@ -6,7 +6,7 @@
   "Name": "Confluence Search",
   "Description": "Search for and open Confluence pages directly from Flow Launcher.",
   "Author": "Jan Haug",
-  "Version": "1.1.0",
+  "Version": "1.2.0",
   "Language": "csharp",
   "Website": "https://github.com/haugjan/Flow.ConfluenceSearch",
   "IcoPath": "Images/icon.png",

--- a/README.md
+++ b/README.md
@@ -56,24 +56,27 @@ The plugin is configured through Flow Launcher's settings interface:
    | Setting | Description | Example |
    |---------|-------------|---------|
    | **Base URL** | Your Confluence instance URL | `https://yourcompany.atlassian.net` |
-   | **API Token** | Cloud: `email:token`. Server / Data Center: token alone. See below. | `your-email@example.com:ATATT3xFfGF0...` |
+   | **Email** | Cloud only: the address you sign in to Atlassian with. Leave empty on Server / Data Center. | `your-email@example.com` |
+   | **API Token** | The API token (Cloud) or personal access token (Server / DC). See below. | `ATATT3xFfGF0...` |
    | **Timeout** | Request timeout in seconds | `10` |
    | **Max Results** | Maximum number of results to display | `10` |
    | **Default Spaces** | Space keys to search by default | `["SPACE1", "SPACE2"]` |
 
 ### Creating a Confluence API Token
 
-1. Go to [Atlassian Account Settings](https://id.atlassian.com/manage-profile/security/api-tokens).
+1. Go to [Atlassian Account Settings](https://id.atlassian.com/manage-profile/security/api-tokens) (also linked from the plugin's settings panel).
 2. Click "Create API token".
 3. Give it a descriptive name (e.g., "Flow Launcher Plugin").
 4. Copy the generated token.
 
-Then paste it into the plugin's **API Token** field, depending on your Confluence flavour:
+Then configure the plugin depending on your Confluence flavour:
 
-- **Confluence Cloud** (`*.atlassian.net`): paste `your-email@example.com:<api-token>` — the address you use to sign in to Atlassian, a colon, and the token, with no spaces. The plugin sends this as HTTP Basic auth, which is what Confluence Cloud requires.
-- **Confluence Server / Data Center**: paste the personal access token alone.
+- **Confluence Cloud** (`*.atlassian.net`): put the address you use to sign in to Atlassian into **Email**, and the API token into **API Token**. The plugin combines them as `email:token` and sends HTTP Basic auth, which is what Confluence Cloud requires.
+- **Confluence Server / Data Center**: leave **Email** empty and paste the personal access token into **API Token** alone.
 
-If authentication fails the plugin shows `Confluence authentication failed (HTTP 401)` in the result list — the most common cause is missing the `email:` prefix on Confluence Cloud.
+> **Backwards compatibility:** earlier versions had a single field where you pasted `email:token`. That still works — if **Email** is empty and **API Token** already contains a colon, the value is used as-is. New configurations should use the two separate fields.
+
+If authentication fails the plugin shows `Confluence authentication failed (HTTP 401)` in the result list — the most common cause on Cloud is a missing or mistyped **Email**.
 
 ## Usage
 
@@ -154,7 +157,7 @@ If you configure default spaces in the settings, searches will automatically be 
 
 ### Authentication Errors
 - Regenerate your API token in Atlassian Account Settings.
-- Ensure you're using your email address as the username (for Atlassian Cloud).
+- On Atlassian Cloud, ensure the **Email** field is filled in with your sign-in address.
 - Check that your account has appropriate permissions.
 
 ## Development


### PR DESCRIPTION
## Summary
- New **Email** field in the settings panel; **API Token** field no longer requires the `email:` prefix.
- Hyperlink under the Token field opens https://id.atlassian.com/manage-profile/security/api-tokens.
- Backwards-compat: legacy `email:token` pasted into the Token field still works when Email is empty.
- Bumps `plugin.json` to `1.2.0`.

Auth-header construction extracted into `AuthHeaderBuilder` with unit tests covering all three modes (separate fields, legacy combined, token-only on-prem).

## Test plan
- [x] Unit cases verified locally (Inline-compile because the local SDK only ships .NET 10 AppHost packs and `dotnet test` cannot satisfy the net9 apphost; CI with .NET 9 SDK runs `AuthHeaderBuilderTest` normally).
- [x] Live verified against `https://confdg.atlassian.net/wiki/rest/api/search?cql=type=page&limit=1`:
  - New mode (Email + Token) → HTTP 200
  - Legacy mode (`email:token` in Token field) → HTTP 200
  - Token-only (on-prem simulation on Cloud) → HTTP 401 (expected)
- [x] Release build of the main project: 0 warnings, 0 errors.